### PR TITLE
Update README to document project initialization, scripts, and toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,42 @@
 
 A static site base on [dumi](https://d.umijs.org).
 
-## Development
+## Project initialization
 
 ```bash
-# install dependencies
-$ pnpm install
+# 1) install dependencies (will run `prepare` automatically)
+pnpm install
 
-# start dev server
-$ pnpm start
+# 2) start local development server
+pnpm start
 
-# build docs
-$ pnpm run build
+# 3) build static docs into dist/
+pnpm run docs:build
+
+# 4) deploy dist/ to GitHub Pages
+pnpm run deploy
 ```
+
+> `prepare` in `package.json` runs `husky install && dumi setup`, so the `.dumi/` runtime files and git hooks are prepared during installation.
+
+## Available tools
+
+### Package scripts
+
+- `pnpm start`: alias of `pnpm run dev`
+- `pnpm run dev`: start dumi development server
+- `pnpm run docs:build`: build production static site to `dist/`
+- `pnpm run deploy`: publish `dist/` using `gh-pages`
+- `pnpm run prepare`: install husky hooks and run `dumi setup`
+
+### Core toolchain
+
+- **dumi**: docs site framework and builder
+- **dumi-theme-antd-style**: visual theme extension
+- **gh-pages**: deployment helper for GitHub Pages
+- **husky**: git hooks manager
+- **commitlint**: commit message linting
+- **prettier**: formatting
 
 ## LICENSE
 


### PR DESCRIPTION
### Motivation
- Clarify how to initialize and run the project, and make the purpose of the `prepare` step explicit for contributors and CI.

### Description
- Replace the `Development` section with a `Project initialization` step-by-step flow that lists `pnpm install`, `pnpm start`, `pnpm run docs:build`, and `pnpm run deploy`.
- Document that `prepare` in `package.json` runs `husky install && dumi setup` so `.dumi/` runtime files and git hooks are created during installation.
- Add an `Available tools` section listing package scripts (`pnpm start`, `pnpm run dev`, `pnpm run docs:build`, `pnpm run deploy`, `pnpm run prepare`) and the core toolchain (`dumi`, `dumi-theme-antd-style`, `gh-pages`, `husky`, `commitlint`, `prettier`).

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4db9466ec833183cd90c6c62d9e23)